### PR TITLE
Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,3 @@ repos:
     rev: v2.13.1-beta
     hooks:
       - id: hadolint-docker
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
-    hooks:
-      - id: prettier
-        additional_dependencies:
-          - "prettier@3.1.0"
-          - "@prettier/plugin-xml@3.3.1"
-        files: \.(xml|xacro|srdf)$

--- a/joint_state_topic_hardware_interface/test/rrr.urdf.xacro
+++ b/joint_state_topic_hardware_interface/test/rrr.urdf.xacro
@@ -111,9 +111,7 @@
   </joint>
   <ros2_control name="name" type="system">
     <hardware>
-      <plugin>
-        joint_state_topic_hardware_interface/JointStateTopicSystem
-      </plugin>
+      <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
       <param name="joint_commands_topic">/topic_based_joint_commands</param>
       <param name="joint_states_topic">/topic_based_joint_states</param>
     </hardware>


### PR DESCRIPTION
The `prettier` pre-commit tool was reformatting the RRR bot URDF and would fail to load the hardware_interface with the error.
```
2: [ros2_control_node-2] [controller_manager 1749215889.526204462]: Caught exception of type : N9pluginlib20LibraryLoadExceptionE while loading hardware: According to the loaded plugin descriptions the class 
2: [ros2_control_node-2]         joint_state_topic_hardware_interface/JointStateTopicSystem
2: [ros2_control_node-2]        with base class type hardware_interface::SystemInterface does not exist. Declared types are  joint_state_topic_hardware_interface/JointStateTopicSystem mock_components/GenericSystem
```